### PR TITLE
Add support for rhel OS family

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,7 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: centos-7.2
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 default['kvexpress']['version'] = '1.12-1'
+default['kvexpress']['download_url'] = 'https://github.com/DataDog/kvexpress/releases/download/v1.12/kvexpress-1.12-linux-amd64.gz'
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
 # Where to place the JSON watches.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,16 +17,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package 'apt-transport-https'
+case node['platform_family']
+when 'debian'
 
-apt_repository 'kvexpress' do
-  uri 'https://packagecloud.io/kvexpress/kvexpress/ubuntu'
-  components ['main']
-  distribution node['lsb']['codename']
-  key 'https://packagecloud.io/gpg.key'
-end
+  package 'apt-transport-https'
 
-package 'kvexpress' do
-  version node['kvexpress']['version']
-  action :install
+  apt_repository 'kvexpress' do
+    uri 'https://packagecloud.io/kvexpress/kvexpress/ubuntu'
+    components ['main']
+    distribution node['lsb']['codename']
+    key 'https://packagecloud.io/gpg.key'
+  end
+
+  package 'kvexpress' do
+    version node['kvexpress']['version']
+    action :install
+  end
+
+when 'rhel'
+
+  # there are no packages available for RHEL family, but fortunately
+  # kvexpress is a single executable
+  cache_filename = "#{Chef::Config[:file_cache_path]}/kvexpress-#{node['kvexpress']['version']}.gz"
+  local_filename = '/usr/bin/kvexpress'
+
+  execute 'install_kvexpress' do
+    creates local_filename
+    command <<-EOF
+      gzip -cd #{cache_filename} > #{local_filename}
+      chmod +x #{local_filename}
+    EOF
+    action :nothing
+  end
+
+  remote_file cache_filename do
+    source node['kvexpress']['download_url']
+    not_if { ::File.exist?(cache_filename) }
+    notifies :run, 'execute[install_kvexpress]', :immediate
+  end
+
 end


### PR DESCRIPTION
Adds support for installing on RHEL based systems from the gzip. The testsuite fails, because there is no consul package. But it also fails for Ubuntu.